### PR TITLE
loosen kim-api pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,5 +267,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@ilia-nikiforov-umn](https://github.com/ilia-nikiforov-umn/)
 * [@jan-janssen](https://github.com/jan-janssen/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,14 +27,14 @@ requirements:
     - pip
     - setuptools
     - pybind11
-    - kim-api =2.3.0
+    - kim-api >=2.3.0
   run:
     - python
     - pip
     - pybind11
     - pytest
     - numpy
-    - kim-api =2.3.0
+    - kim-api >=2.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 889906d60dd4a98dc0983ebf31294256d32966207da112e9a8d94f344ec9510e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Loosen kim-api dependency now that kim-api 2.4.0 is released.